### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: java
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true
 script: true
 
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.